### PR TITLE
Failing when buffers are not real files.

### DIFF
--- a/spacemacs-literate-layering.el
+++ b/spacemacs-literate-layering.el
@@ -153,7 +153,8 @@ is reset."
   :keymap nil
   (cl-flet ((reset-lob () (setq org-babel-library-of-babel
                                 spacemacs-literate-layering--previous-lob)))
-    (cond ((string-match-p "layers/.*/README\\.org\\'" buffer-file-name)
+    (cond (((not buffer-file-name) "")
+           (string-match-p "layers/.*/README\\.org\\'" buffer-file-name)
            (if spacemacs-literate-layering-minor-mode
                (progn
                  (spacemacs-literate|layering//lob-ingest)


### PR DESCRIPTION
`run-hooks: Wrong type argument: stringp, nil` when executed on non-file
buffers, e.g., Org capture buffers. Need to catch such cases and handle them
accordingly.